### PR TITLE
Add legal assistant prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# newforcodextest
+# Legal Assistant Prototype
+
+This repository contains a minimal prototype for a local document management assistant for legal professionals. The application is built using Python and Flask. It can extract text from PDF files or images (screenshots/photographs), store the data in a SQLite database and generate new documents from templates.
+
+## Features
+
+- **OCR and PDF parsing** using `pytesseract` and `PyPDF2`.
+- **Document database** stored in SQLite.
+- **Template rendering** using `docxtpl` (Microsoft Word `.docx` templates).
+- **Simple CLI** via `assistant.py` to process uploaded files.
+- **Flask Admin interface** (see `app.py`) for managing cases, documents and templates.
+
+This is a starting point and does not include a full conversational interface or advanced access controls. It can be extended to run entirely offline on a local server.
+
+## Setup
+
+1. Install dependencies (ideally inside a virtual environment):
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Initialize the database and start the Flask development server:
+
+   ```bash
+   python app.py
+   ```
+
+3. Upload PDF or image files through the admin panel or process them via:
+
+   ```bash
+   python assistant.py "Client Name" path/to/file.pdf
+   ```
+
+## Notes
+
+- `pytesseract` requires the Tesseract OCR engine installed on the system.
+- This project is a minimal demonstration and should be expanded with proper authentication, error handling and a conversational interface for production use.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,47 @@
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from flask_admin import Admin
+from flask_admin.contrib.sqla import ModelView
+import os
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = 'change-me'
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///assistant.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+db = SQLAlchemy(app)
+
+class Client(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(255), nullable=False)
+
+class Case(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(255), nullable=False)
+    client_id = db.Column(db.Integer, db.ForeignKey('client.id'))
+    client = db.relationship('Client', backref=db.backref('cases', lazy=True))
+
+class Document(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    case_id = db.Column(db.Integer, db.ForeignKey('case.id'))
+    case = db.relationship('Case', backref=db.backref('documents', lazy=True))
+    filename = db.Column(db.String(255))
+    text = db.Column(db.Text)
+
+class Template(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(255))
+    path = db.Column(db.String(255))
+
+admin = Admin(app, name='Legal Assistant', template_mode='bootstrap3')
+admin.add_view(ModelView(Client, db.session))
+admin.add_view(ModelView(Case, db.session))
+admin.add_view(ModelView(Document, db.session))
+admin.add_view(ModelView(Template, db.session))
+
+@app.before_first_request
+def setup_db():
+    db.create_all()
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/assistant.py
+++ b/assistant.py
@@ -1,0 +1,105 @@
+import os
+import pytesseract
+from PIL import Image
+from PyPDF2 import PdfReader
+from docxtpl import DocxTemplate
+import sqlite3
+
+DB_PATH = os.environ.get("ASSISTANT_DB", "assistant.db")
+
+CREATE_DOCS_TABLE = """
+CREATE TABLE IF NOT EXISTS documents (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    case TEXT,
+    filename TEXT,
+    text TEXT
+);
+"""
+
+CREATE_TEMPLATES_TABLE = """
+CREATE TABLE IF NOT EXISTS templates (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT,
+    path TEXT
+);
+"""
+
+def init_db(path=DB_PATH):
+    conn = sqlite3.connect(path)
+    cur = conn.cursor()
+    cur.execute(CREATE_DOCS_TABLE)
+    cur.execute(CREATE_TEMPLATES_TABLE)
+    conn.commit()
+    return conn
+
+
+def extract_text_from_image(path: str) -> str:
+    image = Image.open(path)
+    return pytesseract.image_to_string(image)
+
+
+def extract_text_from_pdf(path: str) -> str:
+    reader = PdfReader(path)
+    text = ""
+    for page in reader.pages:
+        text += page.extract_text() or ""
+    return text
+
+
+def save_document(case: str, filename: str, text: str, conn=None):
+    own = False
+    if conn is None:
+        conn = sqlite3.connect(DB_PATH)
+        own = True
+    cur = conn.cursor()
+    cur.execute("INSERT INTO documents(case, filename, text) VALUES (?, ?, ?)", (case, filename, text))
+    conn.commit()
+    if own:
+        conn.close()
+
+
+def load_template(name: str, conn=None):
+    own = False
+    if conn is None:
+        conn = sqlite3.connect(DB_PATH)
+        own = True
+    cur = conn.cursor()
+    cur.execute("SELECT path FROM templates WHERE name=?", (name,))
+    row = cur.fetchone()
+    if own:
+        conn.close()
+    return row[0] if row else None
+
+
+def render_template(name: str, context: dict, output_path: str):
+    template_path = load_template(name)
+    if not template_path:
+        raise FileNotFoundError(f"Template {name} not found")
+    doc = DocxTemplate(template_path)
+    doc.render(context)
+    doc.save(output_path)
+
+
+def process_file(case: str, path: str, conn=None):
+    ext = os.path.splitext(path)[1].lower()
+    if ext in {".png", ".jpg", ".jpeg"}:
+        text = extract_text_from_image(path)
+    elif ext == ".pdf":
+        text = extract_text_from_pdf(path)
+    else:
+        raise ValueError("Unsupported file type")
+    save_document(case, os.path.basename(path), text, conn)
+    return text
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Legal Assistant document processor")
+    parser.add_argument("case", help="case identifier (e.g., client name)")
+    parser.add_argument("file", help="path to pdf or image")
+    args = parser.parse_args()
+
+    init_db()
+    text = process_file(args.case, args.file)
+    print(text)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+Flask
+Flask-Admin
+Flask-Login
+Flask-SQLAlchemy
+pytesseract
+pillow
+PyPDF2
+docxtpl


### PR DESCRIPTION
## Summary
- prototype README describing local legal assistant
- add `assistant.py` to process documents with OCR and PDF parsing
- add `app.py` providing a Flask admin panel using SQLite
- set up Python requirements

## Testing
- `python -m py_compile assistant.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_685b9a2f486c832dbb90dabced626420